### PR TITLE
Remove node fetch, run using npx, import as an ecmascript module

### DIFF
--- a/bin/auth.js
+++ b/bin/auth.js
@@ -23,7 +23,6 @@ export async function auth({ clientId, clientSecret, scope, environment }) {
     body.append('client_id', clientId);
     body.append('client_secret', clientSecret);
     body.append('scope', scope);
-    console.log(body.toString());
     const response = await fetch(url, { headers, method, body: body.toString() });
     const responseBody = await response.json();
     if (!responseBody?.['access_token']) {

--- a/bin/auth.js
+++ b/bin/auth.js
@@ -9,7 +9,6 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import fetch from 'node-fetch';
 export async function auth({ clientId, clientSecret, scope, environment }) {
     const headers = {
         'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
@@ -24,6 +23,7 @@ export async function auth({ clientId, clientSecret, scope, environment }) {
     body.append('client_id', clientId);
     body.append('client_secret', clientSecret);
     body.append('scope', scope);
+    console.log(body.toString());
     const response = await fetch(url, { headers, method, body: body.toString() });
     const responseBody = await response.json();
     if (!responseBody?.['access_token']) {

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import chalk from 'chalk';
-import { auth } from './auth';
+import { auth } from './auth.js';
 const authSchemes = ['oauth-server-to-server'];
 const argv = yargs(hideBin(process.argv))
     .scriptName('@adobe/ims-programmatic-auth')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/auth-token",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/auth-token",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.6",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -14,7 +14,7 @@
         "yargs": "^17.7.2"
       },
       "bin": {
-        "auth-token": "src/index.ts"
+        "auth-token": "bin/index.js"
       },
       "devDependencies": {
         "@babel/core": "^7.22.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/auth-token",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/auth-token",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/auth-token",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/auth-token",
-      "version": "1.0.0-beta.6",
+      "version": "1.0.0-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/auth-token",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Obtain an access token from Adobe",
   "scripts": {
     "build": "rm -rf bin/* && tsc -p tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/auth-token",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Obtain an access token from Adobe",
   "scripts": {
     "build": "rm -rf bin/* && tsc -p tsconfig.json",
@@ -26,10 +26,10 @@
   },
   "type": "module",
   "bin": {
-    "auth-token": "src/index.ts"
+    "auth-token": "./bin/index.js"
   },
   "exports": {
-    "import": "./src/auth.js"
+    ".": "./bin/auth.js"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/auth-token",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "description": "Obtain an access token from Adobe",
   "scripts": {
     "build": "rm -rf bin/* && tsc -p tsconfig.json",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,8 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-// import fetch from 'node-fetch';
-
 type AuthArgs = {
   clientId: string,
   clientSecret: string,
@@ -38,8 +36,6 @@ export async function auth({ clientId, clientSecret, scope, environment }: AuthA
   body.append('client_id', clientId);
   body.append('client_secret', clientSecret);
   body.append('scope', scope);
-
-  console.log(body.toString())
 
   const response = await fetch(url, { headers, method, body: body.toString() });
   const responseBody = await response.json() as AuthResponse;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import fetch from 'node-fetch';
+// import fetch from 'node-fetch';
 
 type AuthArgs = {
   clientId: string,
@@ -38,6 +38,8 @@ export async function auth({ clientId, clientSecret, scope, environment }: AuthA
   body.append('client_id', clientId);
   body.append('client_secret', clientSecret);
   body.append('scope', scope);
+
+  console.log(body.toString())
 
   const response = await fetch(url, { headers, method, body: body.toString() });
   const responseBody = await response.json() as AuthResponse;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ governing permissions and limitations under the License.
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers'
 import chalk from 'chalk';
-import { auth } from './auth'
+import { auth } from './auth.js'
 
 const authSchemes = ['oauth-server-to-server'];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This removes the node fetch dependency which allows the user to do an asynchronous require statement if they aren't ready to move to ecmascript modules. Also resolves an error when trying to use the package when running `npx`.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-10935

## Motivation and Context

Prepare for public availability for our users to gain an access token using server-to-server oauth flow.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.